### PR TITLE
Prevent errors if cURL is actually available.

### DIFF
--- a/src/Purl.php
+++ b/src/Purl.php
@@ -1,6 +1,11 @@
 <?php
 
 /**
+ * Don't do anything if cURL is available.
+ */
+if (!function_exists('curn_init'))
+{
+/**
  * Load cUrl constants and functions definitions 
  */
 require_once 'constants.php';
@@ -320,3 +325,5 @@ class Purl
         }
     }
 }
+
+}  // !function_exists('curl_init')

--- a/src/Purl.php
+++ b/src/Purl.php
@@ -3,7 +3,7 @@
 /**
  * Don't do anything if cURL is available.
  */
-if (!function_exists('curn_init'))
+if (!function_exists('curl_init'))
 {
 /**
  * Load cUrl constants and functions definitions 


### PR DESCRIPTION
If cURL is available in the runtime that this class should be a no-op.

This lets people write apps that use Purl and have them still work when the underlying runtime starts to support cURL.

Thanks!
